### PR TITLE
Migrate from Radix UI to Base UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,90 +2,105 @@
 
 A comprehensive design system for web applications, built with modern tools and best practices.
 
-## 🚀 Overview
+## Overview
 
 Wui Design is a repository workspace containing reusable UI components for building consistent user interfaces across web applications.
 
-## 📦 Packages
+## Packages
 
-### [@wui.design/wui-react](./packages/wui-react/README.md)
+### @wui.design/wui-react
 
 React UI component library with TypeScript support, built on shadcn/ui and Radix UI primitives.
 
-- [📖 Full Documentation](./packages/wui-react/README.md)
-- [🚀 Quick Start](./packages/wui-react/README.md#-quick-start)
-- [🎨 Customization](./packages/wui-react/README.md#-customization)
-- [🧪 Testing](./packages/wui-react/README.md#-testing)
+- [Full Documentation](./packages/wui-react/README.md)
+- [Quick Start](./packages/wui-react/README.md#quick-start)
+- [Customization](./packages/wui-react/README.md#customization)
+- [Testing](./packages/wui-react/README.md#testing)
 
-## 🛠 Development Setup
+## Development Setup
 
 ### Prerequisites
 
-- Node.js 20+
-- pnpm
+- Node.js 20 or higher
+- pnpm package manager
 
 ### Installation
 
+Clone the repository:
+
 ```bash
-# Clone the repository
 git clone https://github.com/webbiffy/wui-design.git
 cd wui-design
+```
 
-# Install dependencies for entire workspace
+Install dependencies:
+
+```bash
+# Install dependencies for entire workspace (recommended for development)
 pnpm install
 
-# OR install dependencies for specific package only
+# OR install dependencies for specific package only (useful for CI/CD)
 pnpm wui-react:install
 ```
 
 #### Installation Options
 
-- **`pnpm install`** - Installs dependencies for **all packages** in the workspace (recommended for development)
-- **`pnpm wui-react:install`** - Installs dependencies for **@wui.design/wui-react package only** (useful for CI/CD or specific deployments)
+- `pnpm install` - Installs dependencies for all packages in the workspace (recommended for development)
+- `pnpm wui-react:install` - Installs dependencies for @wui.design/wui-react package only (useful for CI/CD or specific deployments)
 
 ### Available Scripts
 
-```bash
-# Installation
-pnpm wui-react:install      # Install dependencies for @wui.design/wui-react package only
+#### Installation
 
-# Development
+```bash
+pnpm wui-react:install      # Install dependencies for @wui.design/wui-react package only
+```
+
+#### Development
+
+```bash
 pnpm wui-react:dev          # Start UI React development server
 pnpm wui-react:story        # Start Storybook for component documentation
 pnpm wui-react:build-watch  # Build UI React package and watch for changes
+```
 
-# Testing & Quality
+#### Testing and Quality
+
+```bash
 pnpm wui-react:test         # Run unit tests
 pnpm wui-react:lint         # Run linting
 pnpm wui-react:type-check   # Run TypeScript type checking
+```
 
-# Building
+#### Building
+
+```bash
 pnpm wui-react:build        # Build UI React package
 pnpm wui-react:story-build  # Build Storybook for production
 pnpm wui-react:story-build-with-tests  # Run all tests + build Storybook (recommended for deployment)
 ```
 
-## 🎯 Project Structure
+## Project Structure
 
 ```
 wui-design/
 ├── packages/
-│   └── wui-react/      # React UI components
-├── apps/                  # Testing/demo apps (gitignored)
-├── package.json           # Workspace configuration
-├── pnpm-workspace.yaml    # pnpm workspace setup
-└── README.md              # This file
+│   └── wui-react/          # React UI components
+├── apps/                   # Testing/demo apps (gitignored)
+├── package.json            # Workspace configuration
+├── pnpm-workspace.yaml     # pnpm workspace setup
+└── README.md               # This file
 ```
 
-## 📄 License
+## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
 
-## 👥 Authors
+## Authors
 
 Webster P.
 
-## 🙏 Acknowledgments
+## Acknowledgments
 
 - [shadcn/ui](https://ui.shadcn.com/) for component inspiration
 - [Radix UI](https://www.radix-ui.com/) for accessible primitives

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wui Design
 
-A comprehensive design system for web applications, built with modern tools and best practices.
+A practical design system for web apps, built with modern tools and best practices.
 
 ## Overview
 
@@ -10,7 +10,7 @@ Wui Design is a repository workspace containing reusable UI components for build
 
 ### @wui.design/wui-react
 
-React UI component library with TypeScript support, built on shadcn/ui and Radix UI primitives.
+React UI component library with TypeScript support, built on shadcn/ui and Base UI.
 
 - [Full Documentation](./packages/wui-react/README.md)
 - [Quick Start](./packages/wui-react/README.md#quick-start)
@@ -103,5 +103,5 @@ Webster P.
 ## Acknowledgments
 
 - [shadcn/ui](https://ui.shadcn.com/) for component inspiration
-- [Radix UI](https://www.radix-ui.com/) for accessible primitives
+- [Base UI](https://base-ui.com/) for accessible primitives
 - [Tailwind CSS](https://tailwindcss.com/) for utility-first styling

--- a/packages/wui-react/README.md
+++ b/packages/wui-react/README.md
@@ -9,7 +9,7 @@ A modern, accessible, and customizable UI kit built with React, TypeScript, Tail
 ## Features
 
 - **Modern Design**: Beautiful, clean, and consistent components
-- **Accessibility First**: Built with accessibility in mind using Radix UI primitives
+- **Accessibility First**: Built with accessibility in mind using Base UI
 - **Fully Customizable**: Easy to customize with CSS variables and Tailwind utilities
 - **Tree Shakable**: Only import what you need
 - **Dark Mode Ready**: Built-in dark mode support

--- a/packages/wui-react/README.md
+++ b/packages/wui-react/README.md
@@ -1,25 +1,27 @@
 # Wui UI - React
 
-> 📋 **Part of [Wui Design](../../README.md)** - A comprehensive design system for any react application
+Part of [Wui Design](../../README.md) - A comprehensive design system for any React application.
 
 A modern, accessible, and customizable UI kit built with React, TypeScript, Tailwind CSS, and based on shadcn/ui components. Perfect for building consistent user interfaces across Next.js and React applications.
 
-**🌐 [Live Demo](https://wui-design-react.vercel.app/)** - Explore all components interactively
+[Live Demo](https://wui-design-react.vercel.app/) - Explore all components interactively
 
-## ✨ Features
+## Features
 
-- 🎨 **Modern Design**: Beautiful, clean, and consistent components
-- 🎯 **Accessibility First**: Built with accessibility in mind using Radix UI primitives
-- 🔧 **Fully Customizable**: Easy to customize with CSS variables and Tailwind utilities
-- 📦 **Tree Shakable**: Only import what you need
-- 🎭 **Dark Mode Ready**: Built-in dark mode support
-- 📚 **Storybook Integration**: Interactive component documentation
-- 🧪 **Well Tested**: Comprehensive test coverage with Vitest
-- 🔒 **TypeScript**: Full TypeScript support with proper type definitions
+- **Modern Design**: Beautiful, clean, and consistent components
+- **Accessibility First**: Built with accessibility in mind using Radix UI primitives
+- **Fully Customizable**: Easy to customize with CSS variables and Tailwind utilities
+- **Tree Shakable**: Only import what you need
+- **Dark Mode Ready**: Built-in dark mode support
+- **Storybook Integration**: Interactive component documentation
+- **Well Tested**: Comprehensive test coverage with Vitest
+- **TypeScript**: Full TypeScript support with proper type definitions
 
-## 🚀 Quick Start
+## Quick Start
 
 ### Installation
+
+Install the package using pnpm:
 
 ```bash
 pnpm add @wui.design/wui-react
@@ -27,14 +29,14 @@ pnpm add @wui.design/wui-react
 
 ### Setup
 
-**Import the CSS in your app:**
+Import the CSS in your main app file:
 
 ```tsx
 // In your main app file (e.g., _app.tsx for Next.js or main.tsx for React)
 import "@wui.design/wui-react/styles";
 ```
 
-**For themed versions, import a specific theme:**
+For themed versions, import a specific theme:
 
 ```tsx
 // Themes
@@ -42,11 +44,11 @@ import "@wui.design/wui-react/themes/theme-1";
 import "@wui.design/wui-react/themes/theme-2";
 ```
 
-> 💡 **Note**: Import only one theme at a time. Themes include all necessary base styles, so you don't need to import both `styles` and a theme.
+**Note**: Import only one theme at a time. Themes include all necessary base styles, so you don't need to import both `styles` and a theme.
 
 That's it! The library comes with pre-built CSS, so no additional Tailwind configuration is needed.
 
-## 🎭 Dark Mode
+## Dark Mode
 
 The UI kit supports dark mode out of the box. Simply add the `dark` class to your root element:
 
@@ -55,12 +57,12 @@ The UI kit supports dark mode out of the box. Simply add the `dark` class to you
 document.documentElement.classList.toggle("dark");
 ```
 
-## 🛠 Development
+## Development
 
 ### Prerequisites
 
-- Node.js 20+
-- pnpm
+- Node.js 20 or higher
+- pnpm package manager
 
 ### Available Scripts
 
@@ -72,7 +74,9 @@ document.documentElement.classList.toggle("dark");
 - `pnpm lint` - Lint code
 - `pnpm format` - Format code
 
-## 🧪 Testing
+## Testing
+
+Run tests with the following commands:
 
 ```bash
 # Run tests
@@ -85,9 +89,9 @@ pnpm test:coverage
 pnpm test:ui
 ```
 
-## 📖 Storybook
+## Storybook
 
-View all components in Storybook:
+View all components in Storybook by running:
 
 ```bash
 pnpm storybook
@@ -95,11 +99,11 @@ pnpm storybook
 
 Then open [http://localhost:6006](http://localhost:6006) in your browser.
 
-## 🎨 Customization
+## Customization
 
 ### CSS Variables
 
-Customize the UI kit by overriding CSS variables:
+Customize the UI kit by overriding CSS variables in your own stylesheet:
 
 ```css
 :root {
@@ -111,7 +115,7 @@ Customize the UI kit by overriding CSS variables:
 
 ### Tailwind Configuration
 
-Extend the UI kit with your own Tailwind utilities:
+Extend the UI kit with your own Tailwind utilities by configuring your `tailwind.config.js`:
 
 ```js
 // tailwind.config.js
@@ -130,10 +134,10 @@ module.exports = {
 };
 ```
 
-## 🗂 Workspace Navigation
+## Workspace Navigation
 
 This package is part of the Wui Design workspace:
 
-- **[🏠 Main Repository](../../README.md)** - Workspace setup and overview
-- **[📦 This Package](./README.md)** - You are here
-- **[🚀 Development Scripts](../../README.md#-development-setup)** - Workspace-level commands
+- [Main Repository](../../README.md) - Workspace setup and overview
+- [This Package](./README.md) - You are here
+- [Development Scripts](../../README.md#development-setup) - Workspace-level commands

--- a/packages/wui-react/package.json
+++ b/packages/wui-react/package.json
@@ -100,7 +100,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.0.2"
+    "@base-ui/react": "^1.2.0"
   },
   "keywords": [
     "ui-react",
@@ -108,6 +108,7 @@
     "typescript",
     "tailwindcss",
     "shadcn",
+    "base-ui",
     "components",
     "ui-library"
   ],

--- a/packages/wui-react/src/components/ui/badge/badge.test.tsx
+++ b/packages/wui-react/src/components/ui/badge/badge.test.tsx
@@ -91,10 +91,10 @@ describe("Badge", () => {
     expect(badge).toHaveClass("custom-class");
   });
 
-  it("renders as child when asChild is true", () => {
+  it("renders custom element via render prop", () => {
     render(
-      <Badge asChild>
-        <a href="/test">Link Badge</a>
+      <Badge render={<a href="/test" />}>
+        Link Badge
       </Badge>
     );
 

--- a/packages/wui-react/src/components/ui/badge/badge.test.tsx
+++ b/packages/wui-react/src/components/ui/badge/badge.test.tsx
@@ -93,7 +93,7 @@ describe("Badge", () => {
 
   it("renders custom element via render prop", () => {
     render(
-      <Badge render={<a href="/test" />}>
+      <Badge render={<a href="/test" aria-label="Link Badge" />}>
         Link Badge
       </Badge>
     );

--- a/packages/wui-react/src/components/ui/badge/badge.tsx
+++ b/packages/wui-react/src/components/ui/badge/badge.tsx
@@ -1,4 +1,4 @@
-import { Slot } from "@radix-ui/react-slot";
+import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
@@ -29,7 +29,7 @@ const badgeVariants = cva(
         "filled-danger":
           "wui-border-transparent wui-bg-danger wui-text-danger-foreground [a&]:hover:wui-bg-danger/90",
         "filled-informative":
-         "wui-border-transparent wui-bg-informative wui-text-informative-foreground [a&]:hover:wui-bg-informative/90",
+          "wui-border-transparent wui-bg-informative wui-text-informative-foreground [a&]:hover:wui-bg-informative/90",
       },
       size: {
         default: "wui-text-xs wui-py-0.5 wui-px-2",
@@ -47,13 +47,13 @@ const badgeVariants = cva(
       size: "default",
       radius: "default",
     },
-  }
+  },
 );
 
 interface BadgeProps
   extends React.ComponentProps<"span">,
     VariantProps<typeof badgeVariants> {
-  asChild?: boolean;
+  render?: React.ReactElement;
 }
 
 function Badge({
@@ -61,18 +61,20 @@ function Badge({
   variant,
   size,
   radius,
-  asChild = false,
+  render,
   ...props
 }: React.ComponentProps<"span"> & BadgeProps) {
-  const Comp = asChild ? Slot : "span";
+  const element = useRender({
+    defaultTagName: "span",
+    render,
+    props: {
+      "data-slot": "badge",
+      className: cn(badgeVariants({ variant, size, radius }), className),
+      ...props,
+    },
+  });
 
-  return (
-    <Comp
-      data-slot="badge"
-      className={cn(badgeVariants({ variant, size, radius }), className)}
-      {...props}
-    />
-  );
+  return element;
 }
 
 export { Badge, type BadgeProps };

--- a/packages/wui-react/src/components/ui/button/button.test.tsx
+++ b/packages/wui-react/src/components/ui/button/button.test.tsx
@@ -94,10 +94,10 @@ describe("Button", () => {
     expect(button).toHaveClass("custom-class");
   });
 
-  it("renders as child when asChild is true", () => {
+  it("renders custom element via render prop", () => {
     render(
-      <Button asChild>
-        <a href="/test">Link Button</a>
+      <Button render={<a href="/test" />}>
+        Link Button
       </Button>
     );
 

--- a/packages/wui-react/src/components/ui/button/button.test.tsx
+++ b/packages/wui-react/src/components/ui/button/button.test.tsx
@@ -96,7 +96,7 @@ describe("Button", () => {
 
   it("renders custom element via render prop", () => {
     render(
-      <Button render={<a href="/test" />}>
+      <Button render={<a href="/test" aria-label="Link Button" />}>
         Link Button
       </Button>
     );

--- a/packages/wui-react/src/components/ui/button/button.tsx
+++ b/packages/wui-react/src/components/ui/button/button.tsx
@@ -1,4 +1,4 @@
-import { Slot } from "@radix-ui/react-slot";
+import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
@@ -71,19 +71,22 @@ const buttonVariants = cva(
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
+  render?: React.ReactElement | ((props: any) => React.ReactElement);
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button";
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    );
+  ({ className, variant, size, render, ...props }, ref) => {
+    const element = useRender({
+      defaultTagName: "button",
+      render,
+      props: {
+        className: cn(buttonVariants({ variant, size, className })),
+        ref,
+        ...props,
+      },
+    });
+
+    return element;
   }
 );
 Button.displayName = "Button";

--- a/packages/wui-react/src/components/ui/button/button.tsx
+++ b/packages/wui-react/src/components/ui/button/button.tsx
@@ -65,13 +65,13 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
+  },
 );
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  render?: React.ReactElement | ((props: any) => React.ReactElement);
+  render?: React.ReactElement;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
@@ -87,7 +87,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     });
 
     return element;
-  }
+  },
 );
 Button.displayName = "Button";
 

--- a/packages/wui-react/src/data/changelog.ts
+++ b/packages/wui-react/src/data/changelog.ts
@@ -21,6 +21,21 @@ export interface ChangelogSection {
 
 export const changelog: ChangelogSection[] = [
   {
+    version: "1.2.0",
+    changes: [
+      {
+        type: "minor",
+        description: "# Add \"informative\" variant",
+        pr: "#8",
+        prUrl: "https://github.com/webbiffy/wui-design/pull/8",
+        commit: "5cfb5d9",
+        commitUrl: "https://github.com/webbiffy/wui-design/commit/5cfb5d94f202d6cf3f0954808fe85b6578132a6d",
+        author: "VivianMrnd",
+        authorUrl: "https://github.com/VivianMrnd"
+      }
+    ]
+  },
+  {
     version: "1.1.0",
     changes: [
       {
@@ -29,8 +44,7 @@ export const changelog: ChangelogSection[] = [
         pr: "#4",
         prUrl: "https://github.com/webbiffy/wui-design/pull/4",
         commit: "3f9730f",
-        commitUrl:
-          "https://github.com/webbiffy/wui-design/commit/3f9730f8ca91b291aec479c2b8a3c82679f585d5",
+        commitUrl: "https://github.com/webbiffy/wui-design/commit/3f9730f8ca91b291aec479c2b8a3c82679f585d5",
         author: "webbiffy",
         authorUrl: "https://github.com/webbiffy",
         details: [
@@ -38,8 +52,8 @@ export const changelog: ChangelogSection[] = [
           "Support for different sizes (default, sm, md) and radius options",
           "Comprehensive test suite with 10 test cases",
           "Update theme colors for better dark mode contrast",
-          "Fix Storybook brand title to use dynamic versioning",
-        ],
+          "Fix Storybook brand title to use dynamic versioning"
+        ]
       },
       {
         type: "patch",
@@ -47,12 +61,11 @@ export const changelog: ChangelogSection[] = [
         pr: "#4",
         prUrl: "https://github.com/webbiffy/wui-design/pull/4",
         commit: "3f9730f",
-        commitUrl:
-          "https://github.com/webbiffy/wui-design/commit/3f9730f8ca91b291aec479c2b8a3c82679f585d5",
+        commitUrl: "https://github.com/webbiffy/wui-design/commit/3f9730f8ca91b291aec479c2b8a3c82679f585d5",
         author: "webbiffy",
-        authorUrl: "https://github.com/webbiffy",
-      },
-    ],
+        authorUrl: "https://github.com/webbiffy"
+      }
+    ]
   },
   {
     version: "1.0.1",
@@ -61,11 +74,10 @@ export const changelog: ChangelogSection[] = [
         type: "patch",
         description: "initial release for wui design - react",
         commit: "8e88c59",
-        commitUrl:
-          "https://github.com/webbiffy/wui-design/commit/8e88c599e5b6e28113fea73303ebb4b08cde06ff",
+        commitUrl: "https://github.com/webbiffy/wui-design/commit/8e88c599e5b6e28113fea73303ebb4b08cde06ff",
         author: "webbiffy",
-        authorUrl: "https://github.com/webbiffy",
-      },
-    ],
-  },
+        authorUrl: "https://github.com/webbiffy"
+      }
+    ]
+  }
 ];

--- a/packages/wui-react/tailwind.config.ts
+++ b/packages/wui-react/tailwind.config.ts
@@ -59,20 +59,6 @@ const config: Config = {
         md: "calc(var(--wui-radius) - 2px)",
         sm: "calc(var(--wui-radius) - 4px)",
       },
-      keyframes: {
-        "accordion-down": {
-          from: { height: "0" },
-          to: { height: "var(--radix-accordion-content-height)" },
-        },
-        "accordion-up": {
-          from: { height: "var(--radix-accordion-content-height)" },
-          to: { height: "0" },
-        },
-      },
-      animation: {
-        "accordion-down": "accordion-down 0.2s ease-out",
-        "accordion-up": "accordion-up 0.2s ease-out",
-      },
     },
   },
   plugins: [tailwindcssAnimate],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,9 @@ importers:
 
   packages/wui-react:
     dependencies:
-      '@radix-ui/react-slot':
-        specifier: ^1.0.2
-        version: 1.2.3(@types/react@18.3.23)(react@18.3.1)
+      '@base-ui/react':
+        specifier: ^1.2.0
+        version: 1.2.0(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.30.1
@@ -244,16 +244,16 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/runtime@7.27.6':
-    resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/runtime@7.28.2':
     resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
@@ -267,6 +267,27 @@ packages:
   '@babel/types@7.28.0':
     resolution: {integrity: sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.2.0':
+    resolution: {integrity: sha512-O6aEQHcm+QyGTFY28xuwRD3SEJGZOBDpyjN2WvpfWYFVhg+3zfXPysAILqtM0C1kWC82MccOE/v1j+GHXE4qIw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@base-ui/utils@0.2.5':
+    resolution: {integrity: sha512-oYC7w0gp76RI5MxprlGLV0wze0SErZaRl3AAkeP3OnNB/UBMb6RqNf6ZSIlxOc9Qp68Ab3C2VOcJQyRs7Xc7Vw==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -723,6 +744,21 @@ packages:
     resolution: {integrity: sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@floating-ui/core@1.7.4':
+    resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
+
+  '@floating-ui/dom@1.7.5':
+    resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
+
+  '@floating-ui/react-dom@2.1.7':
+    resolution: {integrity: sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -827,24 +863,6 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
-
-  '@radix-ui/react-compose-refs@1.1.2':
-    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-slot@1.2.3':
-    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.19':
     resolution: {integrity: sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA==}
@@ -2980,6 +2998,9 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3233,6 +3254,9 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
   tailwind-merge@2.6.0:
     resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
 
@@ -3410,6 +3434,11 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -3737,11 +3766,11 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/runtime@7.27.6': {}
-
   '@babel/runtime@7.28.2': {}
 
   '@babel/runtime@7.28.4': {}
+
+  '@babel/runtime@7.28.6': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -3765,6 +3794,30 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@base-ui/react@1.2.0(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@base-ui/utils': 0.2.5(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react-dom': 2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.10
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.4.0
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+
+  '@base-ui/utils@0.2.5(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@floating-ui/utils': 0.2.10
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -4165,6 +4218,23 @@ snapshots:
       '@eslint/core': 0.15.1
       levn: 0.4.1
 
+  '@floating-ui/core@1.7.4':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.5':
+    dependencies:
+      '@floating-ui/core': 1.7.4
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/react-dom@2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@floating-ui/utils@0.2.10': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -4218,14 +4288,14 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.4
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.4
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -4298,19 +4368,6 @@ snapshots:
     optional: true
 
   '@polka/url@1.0.0-next.29': {}
-
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.23)(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.23
-
-  '@radix-ui/react-slot@1.2.3(@types/react@18.3.23)(react@18.3.1)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@18.3.1)
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.23
 
   '@rolldown/pluginutils@1.0.0-beta.19': {}
 
@@ -6648,6 +6705,8 @@ snapshots:
 
   requires-port@1.0.0: {}
 
+  reselect@5.1.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -6977,6 +7036,8 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  tabbable@6.4.0: {}
+
   tailwind-merge@2.6.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.17):
@@ -7203,6 +7264,10 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Summary

  This PR migrates the component library from Radix UI to Base UI, aligning with
   the latest shadcn/ui direction.

  ### Key Changes

  - **Replaced dependency**: `@radix-ui/react-slot` → `@base-ui/react`
  - **Updated components**: Button and Badge now use Base UI's `useRender` hook
  - **API change**: `asChild` prop replaced with `render` prop (breaking change)
  - **Documentation**: Updated all references from Radix UI to Base UI
  - **Cleanup**: Removed unused Radix-specific Tailwind animations

  ### Breaking Change ⚠️

  The `asChild` prop has been replaced with the `render` prop on Button and
  Badge components.

  **Migration Guide:**

  ```tsx
  // Before (Radix UI)
  <Button asChild>
    <Link to="/home">Home</Link>
  </Button>

  // After (Base UI)
  <Button render={<Link to="/home" />}>
    Home
  </Button>

  Why This Change?

  - Align with the latest shadcn/ui ecosystem using Base UI
  - Address concerns about Radix UI maintenance status
  - Prepare the library for future Base UI component adoption

  Impact

  - This is a major version change (requires v2.0.0 bump)
  - All existing variants and functionality remain unchanged
  - Minimal bundle size impact (both libraries are lightweight)

  Test Plan

  - All tests passing (17/17)
  - TypeScript compilation successful
  - Build completes without errors
  - Button component tests updated for new API
  - Badge component tests updated for new API
  - Manual testing in Storybook
  - Visual regression testing
  - Test with React Router Link
  - Test with Next.js Link